### PR TITLE
chore(deps): pin packages and run npm up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
+    assignees:
+      - arcjet/dx-team
+    reviewers:
+      - arcjet/dx-team
     commit-message:
       prefix: deps
       prefix-development: deps(dev)
@@ -22,5 +26,6 @@ updates:
           - arcjet
           - "@arcjet/*"
     ignore:
-      - dependency-name: eslint
-        versions: [">=9"]
+      # Synced with engines field in package.json
+      - dependency-name: '@types/node'
+        versions: ['>=21']

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,14 @@
       "name": "example-expressjs",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/inspect": "^1.0.0-beta.7",
-        "@arcjet/node": "^1.0.0-beta.7",
-        "express": "^5.1.0"
+        "@arcjet/inspect": "1.0.0-beta.7",
+        "@arcjet/node": "1.0.0-beta.7",
+        "express": "5.1.0"
       },
       "devDependencies": {
-        "@types/express": "^5.0.2",
-        "@types/node": "^22.15.18",
-        "typescript": "^5.8.3"
+        "@types/express": "5.0.2",
+        "@types/node": "^20",
+        "typescript": "5.8.3"
       },
       "engines": {
         "node": ">=20"
@@ -297,13 +297,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+      "version": "20.17.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.49.tgz",
+      "integrity": "sha512-lu4U+g0EbSW2aPGksNyqcesB2D3eDD0mv8ig9youJsEs/DuMOdeqcEbFOBDCCurXNpa10NkKSSRfOQLBFCiD8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/qs": {
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "start": "tsc && node --env-file .env.local dist/index.js"
   },
   "dependencies": {
-    "@arcjet/inspect": "^1.0.0-beta.7",
-    "@arcjet/node": "^1.0.0-beta.7",
-    "express": "^5.1.0"
+    "@arcjet/inspect": "1.0.0-beta.7",
+    "@arcjet/node": "1.0.0-beta.7",
+    "express": "5.1.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.2",
-    "@types/node": "^22.15.18",
-    "typescript": "^5.8.3"
+    "@types/express": "5.0.2",
+    "@types/node": "^20",
+    "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
Pin packages in package.json for clarity. Notably sync `@types/node` to match engines field.