### PR TITLE
chore: remove assignees and reviewers from dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    assignees:
-      - arcjet/dx-team
-    reviewers:
-      - arcjet/dx-team
     commit-message:
       prefix: deps
       prefix-development: deps(dev)
@@ -27,5 +23,5 @@ updates:
           - "@arcjet/*"
     ignore:
       # Synced with engines field in package.json
-      - dependency-name: '@types/node'
-        versions: ['>=21']
+      - dependency-name: "@types/node"
+        versions: [">=21"]


### PR DESCRIPTION
Fixes #6 + a cheeky trunk fmt, note that CODEOWNERS already has the dx-team set