### PR TITLE
chore: Initial publish from monorepo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,25 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
-    "name": "Arcjet example: Express.js",
-    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
-    "features": {
-        "ghcr.io/trunk-io/devcontainer-feature/trunk:1": {}
-    },
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "trunk.io"
-            ]
-        }
+  "name": "Arcjet example: Express.js",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+  "features": {
+    "ghcr.io/trunk-io/devcontainer-feature/trunk:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["trunk.io"]
     }
-    // Features to add to the dev container. More info: https://containers.dev/features.
-    // "features": {},
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-    // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "yarn install",
-    // Configure tool-specific properties.
-    // "customizations": {},
-    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-    // "remoteUser": "root"
+  }
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "yarn install",
+  // Configure tool-specific properties.
+  // "customizations": {},
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD033 MD041 -->
 <a href="https://arcjet.com" target="_arcjet-home">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://arcjet.com/logo/arcjet-dark-lockup-voyage-horizontal.svg">
@@ -49,3 +50,16 @@ npm run start
 Check out [the docs](https://docs.arcjet.com/), [contact
 support](https://docs.arcjet.com/support), or [join our Discord
 server](https://arcjet.com/discord).
+
+## Contributing
+
+All development for Arcjet examples is done in the
+[`arcjet/examples` repository](https://github.com/arcjet/examples).
+
+You are welcome to open an issue here or in
+[`arcjet/examples`](https://github.com/arcjet/examples/issues) directly.
+However, please direct all pull requests to
+[`arcjet/examples`](https://github.com/arcjet/examples/pulls). Take a look at
+our
+[contributing guide](https://github.com/arcjet/examples/blob/main/CONTRIBUTING.md)
+for more information.

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,12 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { isSpoofedBot } from "@arcjet/inspect";
 import arcjet, { detectBot, shield, slidingWindow } from "@arcjet/node";
-import express, { Request, Response, NextFunction } from "express";
-import path from "path";
-import { fileURLToPath } from "url";
+import express, {
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,62 +14,68 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const port = 3000;
 
+if (!process.env.ARCJET_KEY) {
+  throw new Error(
+    "ARCJET_KEY environment variable is required. Sign up for your Arcjet key at https://app.arcjet.com",
+  );
+}
+
 const aj = arcjet({
-    // Get your site key from https://app.arcjet.com
-    key: process.env.ARCJET_KEY!,
-    rules: [
-        // Shield protects your app from common attacks e.g. SQL injection
-        shield({ mode: "LIVE" }),
-        // Create a bot detection rule
-        detectBot({
-            mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-            // Block all bots except the following
-            allow: [
-                // See the full list at https://arcjet.com/bot-list
-                "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
-                "CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
-            ],
-        }),
-        // Create a token bucket rate limit. Other algorithms are supported.
-        slidingWindow({
-            mode: "LIVE",
-            interval: "2s", // Refill every 2 seconds
-            max: 5, // Allow 5 requests per interval
-        }),
-    ],
+  // Get your site key from https://app.arcjet.com
+  key: process.env.ARCJET_KEY,
+  rules: [
+    // Shield protects your app from common attacks e.g. SQL injection
+    shield({ mode: "LIVE" }),
+    // Create a bot detection rule
+    detectBot({
+      mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
+      // Block all bots except the following
+      allow: [
+        // See the full list at https://arcjet.com/bot-list
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        "CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
+    }),
+    // Create a token bucket rate limit. Other algorithms are supported.
+    slidingWindow({
+      mode: "LIVE",
+      interval: "2s", // Refill every 2 seconds
+      max: 5, // Allow 5 requests per interval
+    }),
+  ],
 });
 
 // Arcjet middleware
 app.use(async (req: Request, res: Response, next: NextFunction) => {
-    const decision = await aj.protect(req);
+  const decision = await aj.protect(req);
 
-    console.log("Arcjet decision:", decision);
+  console.log("Arcjet decision:", decision);
 
-    if (decision.isDenied()) {
-        if (decision.reason.isBot()) {
-            res.writeHead(403, { "Content-Type": "text/html" });
-            res.end("<h1>Forbidden</h1><p>Bots denied.</p>");
-        } else if (decision.reason.isRateLimit()) {
-            res.writeHead(429, { "Content-Type": "text/html" });
-            res.end("<h1>Too Many Requests</h1><p>Rate limit exceeded.</p>");
-        } else {
-            res.writeHead(403, { "Content-Type": "text/html" });
-            res.end("<h1>Forbidden</h1><p>Access denied.</p>");
-        }
-    }
-    // https://docs.arcjet.com/bot-protection/reference#bot-verification
-    // Test it with:
-    // `curl -H "User-Agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" http://localhost:3000`
-    else if (decision.results.some(isSpoofedBot)) {
-        res.writeHead(403, { "Content-Type": "text/html" });
-        res.end("<h1>Forbidden</h1><p>No spoofing!</p>");
+  if (decision.isDenied()) {
+    if (decision.reason.isBot()) {
+      res.writeHead(403, { "Content-Type": "text/html" });
+      res.end("<h1>Forbidden</h1><p>Bots denied.</p>");
+    } else if (decision.reason.isRateLimit()) {
+      res.writeHead(429, { "Content-Type": "text/html" });
+      res.end("<h1>Too Many Requests</h1><p>Rate limit exceeded.</p>");
     } else {
-        next();
+      res.writeHead(403, { "Content-Type": "text/html" });
+      res.end("<h1>Forbidden</h1><p>Access denied.</p>");
     }
+  }
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  // Test it with:
+  // `curl -H "User-Agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" http://localhost:3000`
+  else if (decision.results.some(isSpoofedBot)) {
+    res.writeHead(403, { "Content-Type": "text/html" });
+    res.end("<h1>Forbidden</h1><p>No spoofing!</p>");
+  } else {
+    next();
+  }
 });
 
 app.use(express.static(path.join(__dirname, "../public")));
 
 app.listen(port, () => {
-    console.log(`Example app listening on port ${port}`);
+  console.log(`Example app listening on port ${port}`);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "example-expressjs",
+  "name": "@arcjet-examples/expressjs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "example-expressjs",
+      "name": "@arcjet-examples/expressjs",
       "license": "Apache-2.0",
       "dependencies": {
         "@arcjet/inspect": "1.0.0-beta.9",
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
+      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -308,8 +308,6 @@
     },
     "node_modules/@types/node": {
       "version": "20.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
-      "integrity": "sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -331,9 +329,9 @@
       "license": "MIT"
     },
     "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -342,9 +340,9 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -756,6 +754,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -1116,9 +1123,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1184,8 +1191,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,16 +1,12 @@
 {
-  "name": "example-expressjs",
+  "name": "@arcjet-examples/expressjs",
   "type": "module",
   "description": "An example Express.js application protected by Arcjet bot detection, rate limiting, and Shield WAF.",
   "license": "Apache-2.0",
   "homepage": "https://arcjet.com",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/arcjet/example-expressjs.git",
-    "directory": "arcjet"
-  },
+  "repository": "github:arcjet/example-expressjs",
   "bugs": {
-    "url": "https://github.com/arcjet/example-expressjs/issues",
+    "url": "https://github.com/arcjet/examples/issues",
     "email": "support@arcjet.com"
   },
   "author": {

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Hello World</title>
-</head>
-<body>
-  <h1>Hello world</h1>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hello World</title>
+  </head>
+  <body>
+    <h1>Hello world</h1>
+  </body>
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "ESNext", /* Specify what module code is generated. */
-    "moduleResolution": "Node", /* Specify how TypeScript looks up a file from a given module specifier. */
-    "resolveJsonModule": true, /* Enable importing .json files. */
-    "noEmit": false, /* Disable emitting files from a compilation. */
-    "outDir": "./dist", /* Specify an output folder for all emitted files. */
-    "allowSyntheticDefaultImports": true, /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
-    "strict": true, /* Enable all strict type-checking options. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "module": "ESNext" /* Specify what module code is generated. */,
+    "moduleResolution": "Node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "resolveJsonModule": true /* Enable importing .json files. */,
+    "noEmit": false /* Disable emitting files from a compilation. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "strict": true /* Enable all strict type-checking options. */,
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
Via the work in https://github.com/arcjet/examples/pull/17

This is a consequence of the work to move development of this repository to the `examples` monorepo. This diff is _much_ easier to read.

Note that most of the changes are due to the standardized linting and formatting in the examples repo (notably the sorted imports for this diff).

In the future, the workflow will not include a pull request but will instead push to `main` directly.

Actions for merging:
- [ ] Remove push protection from `main` (sorry, I know we just added it)
- [ ] Merge this without squashing